### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: rust
 cache: cargo
 
 rust:
-  - 1.36
+  - 1.36.0
   - stable
   - beta
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,56 @@
+dist: xenial
+
+language: rust
+cache: cargo
+
+rust:
+  - 1.36
+  - stable
+  - beta
+  - nightly
+
+env:
+  global:
+    - RUN_TEST=true
+    - RUN_CLIPPY=false
+    - RUN_BENCH=false
+
+matrix:
+  fast_finish: true
+  include:
+    - &rustfmt_build
+      rust: "stable"
+      env:
+        - RUN_RUSTFMT=true
+        - RUN_TEST=false
+    - &clippy_build
+      rust: "stable"
+      env:
+        - RUN_CLIPPY=true
+        - RUN_TEST=false
+
+before_script:
+  - bash -c 'if [[ "$RUN_RUSTFMT" == "true" ]]; then
+      rustup component add rustfmt
+      ;
+    fi'
+  - bash -c 'if [[ "$RUN_CLIPPY" == "true" ]]; then
+      rustup component add clippy
+      ;
+    fi'
+
+script:
+  - bash -c 'if [[ "$RUN_TEST" == "true" ]]; then
+      export CI_RUST_VERSION="$TRAVIS_RUST_VERSION";
+      cargo test --verbose --all;
+    fi'
+  - bash -c 'if [[ "$RUN_RUSTFMT" == "true" ]]; then
+      cargo fmt -v -- --check;
+    fi'
+  - bash -c 'if [[ "$RUN_CLIPPY" == "true" ]]; then
+      cargo clippy -- -D warnings;
+    fi'
+
+notifications:
+  email:
+    on_success: never

--- a/changelog/src/changelog.rs
+++ b/changelog/src/changelog.rs
@@ -44,7 +44,7 @@ impl From<&str> for Version {
 
 impl Version {
     fn extract_epoch(value: &str) -> Result<Option<u8>> {
-        let vec: Vec<&str> = value.split(":").collect();
+        let vec: Vec<&str> = value.split(':').collect();
         match vec[0].parse::<u8>() {
             Ok(v) => Ok(Some(v)),
             Err(_) => Ok(None)
@@ -52,8 +52,8 @@ impl Version {
     }
 
     fn extract_upstream(value: &str) -> Result<String> {
-        let vec: Vec<&str> = value.split(":").collect();
-        let idx = if !Self::extract_epoch(value).is_ok() {
+        let vec: Vec<&str> = value.split(':').collect();
+        let idx = if Self::extract_epoch(value).is_err() {
             0
         } else {
             1
@@ -65,7 +65,7 @@ impl Version {
     }
 
     fn extract_package(value: &str) -> Result<String> {
-        let vec: Vec<&str> = value.split("-").collect();
+        let vec: Vec<&str> = value.split('-').collect();
         match vec[1].parse::<String>() {
             Ok(v) => Ok(v),
             Err(s) => Err(Error::VersionError(s.to_string()))
@@ -110,7 +110,7 @@ pub struct ChangeLog {
 
 impl ChangeLog {
     pub fn new(workdir: PathBuf) -> ChangeLog {
-        ChangeLog { workdir: workdir }
+        ChangeLog { workdir }
     }
 
     pub fn get_head_full_version(&self) -> String {
@@ -125,7 +125,7 @@ impl ChangeLog {
 
     pub fn get_head_epoch(&self) -> Option<u32> {
         let ver = self.get_head_full_version();
-        let vec: Vec<&str> = ver.split(":").collect();
+        let vec: Vec<&str> = ver.split(':').collect();
         match vec[0].parse::<u32>() {
             Ok(v) => Some(v),
             Err(_) => None,
@@ -134,14 +134,14 @@ impl ChangeLog {
 
     pub fn get_head_version(&self) -> Option<String> {
         let ver = self.get_head_full_version();
-        let vec: Vec<&str> = ver.split(":").collect();
+        let vec: Vec<&str> = ver.split(':').collect();
         if vec.len() > 1 {
             match vec[1].parse::<String>() {
                 Ok(v) => return Some(v),
                 Err(_) => return None,
             }
         }
-        return Some(ver);
+        Some(ver)
     }
 
     pub fn new_release(&self, version: &str, message: ChangeLogMessage) {

--- a/git/src/git.rs
+++ b/git/src/git.rs
@@ -86,7 +86,7 @@ impl Git {
     pub fn new(name: &str, rootdir: PathBuf, url: GitCloneUrl) -> Result<Git> {
         let mut workdir = rootdir.clone();
         workdir.push(name);
-        let git = Git { workdir: workdir };
+        let git = Git { workdir };
         if !git.exists() {
             Command::new("mkdir").arg("-p").arg(&rootdir).status()?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use std::process::Command;
 use changelog::ChangeLog;
 use git::{Git, GitCloneUrl};
 
-static GIT_STABLE_BRANCH: &'static str = "stable";
+static GIT_STABLE_BRANCH: &str = "stable";
 
 #[derive(Debug)]
 pub enum Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,13 +66,13 @@ impl Package {
         // I should refer gbp.conf
         let mut builddir = rootdir.clone();
         builddir.push("build-area");
-        Command::new("mkdir").arg("-p").arg(builddir).status();
+        let _ = Command::new("mkdir").arg("-p").arg(builddir).status();
 
         let mut workdir = rootdir.clone();
         workdir.push(name);
         Package {
             name: name.to_string(),
-            rootdir: rootdir,
+            rootdir,
             workdir: workdir.clone(),
             changelog: ChangeLog::new(workdir.clone()),
             git: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,9 +18,9 @@ use changelog::ChangeLogMessage;
 use clap::{App, AppSettings, Arg, SubCommand};
 use uosp::*;
 
-const OS_MASTER: &'static str = "train";
-const KIND_OPENSTACK: &'static str = "openstack";
-const KIND_REGULAR: &'static str = "regular";
+const OS_MASTER: &str = "train";
+const KIND_OPENSTACK: &str = "openstack";
+const KIND_REGULAR: &str = "regular";
 
 fn get_current_dir() -> std::path::PathBuf {
     std::env::current_dir().unwrap()
@@ -81,7 +81,10 @@ fn rebase(
             uppercase_first_letter(OS_MASTER)
         };
         if bugid.is_some() {
-            ChangeLogMessage::OSNewStablePointReleaseWithBug(formated_name, bugid.unwrap().to_string())
+            ChangeLogMessage::OSNewStablePointReleaseWithBug(
+                formated_name,
+                bugid.unwrap().to_string(),
+            )
         } else {
             ChangeLogMessage::OSNewStablePointRelease(formated_name)
         }
@@ -132,13 +135,13 @@ fn snapshot(name: &str, version: &str, upstream: Option<&str>) -> Result<()> {
 
     // Wanning that the process is not yet finished.
     // TODO(sahid): implement some sort of magic to handle deps.
-    println!("");
+    println!();
     println!("/!\\ Please consider to check (build-)deps.");
 
     Ok(())
 }
 
-fn debdiff(name: &str, release: &str, patch: &str, upstream: Option<&str>) -> Result<()> {
+fn debdiff(name: &str, release: &str, patch: &str, _upstream: Option<&str>) -> Result<()> {
     let workdir = get_current_dir();
     let branch = Package::format_branch(release);
 
@@ -154,7 +157,7 @@ fn debdiff(name: &str, release: &str, patch: &str, upstream: Option<&str>) -> Re
         git.apply_from_url(patch)?;
     } else {
         // localpatch
-        let mut file = std::path::PathBuf::from(get_current_dir());
+        let mut file = get_current_dir();
         file.push(patch);
         git.apply_from_file(file)?;
     }
@@ -196,7 +199,7 @@ fn publish(name: &str, ppa: &str, serie: &str, fake: bool, build: bool) -> Resul
     if !build {
         pkg.build()?;
     }
-    pkg.publish(ppa, serie, true);
+    pkg.publish(ppa, serie, true)?;
 
     Ok(())
 }


### PR DESCRIPTION
This pull adds the ability to connect to Travis for CI, as well as
updating to handle the formatting and lints suggested by rustfmt
and clippy.